### PR TITLE
Apply autoformatting for consistency.  Add missing typehints.  Turn on strict_types.

### DIFF
--- a/src/Lesson1AStraight.php
+++ b/src/Lesson1AStraight.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace LearnWithLlew;
 

--- a/src/Lesson2AVariable.php
+++ b/src/Lesson2AVariable.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace LearnWithLlew;
 

--- a/src/Lesson2B.php
+++ b/src/Lesson2B.php
@@ -11,7 +11,7 @@ class Lesson2B extends Song
         switch ($style) {
             case 1 :
                 foreach ($names as $name) {
-                    if (substr( $name, 0, strlen("L")) === "L") {
+                    if (substr($name, 0, strlen("L")) === "L") {
                         $this->sing("Hip Hip Horray! For " . $name);
                     } else {
                         $this->sing("Hello " . $name . ", it's nice to meet you.");
@@ -20,7 +20,7 @@ class Lesson2B extends Song
                 break;
             case 2 :
                 foreach ($names as $name) {
-                    if (substr( $name, 1, strlen("am")) === "am") {
+                    if (substr($name, 1, strlen("am")) === "am") {
                         $this->sing("Say yeah! Say yo! Say " . $name);
                     } else {
                         $this->sing("Hello " . $name . ", it's nice to meet you.");

--- a/src/Lesson2B.php
+++ b/src/Lesson2B.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace LearnWithLlew;
 

--- a/src/Lesson3AHigherOrderFunctions.php
+++ b/src/Lesson3AHigherOrderFunctions.php
@@ -1,45 +1,45 @@
 <?php
-
+declare(strict_types=1);
 
 namespace LearnWithLlew;
 
 
 class Lesson3AHigherOrderFunctions extends Song
 {
-    public function singCheers()
-  {
-    $number = 2;
-    $this->sing($number . "! ");
-    $number = $number + 2;
-    $this->sing($number . "! ");
-    $number = $number + 2;
-    $this->sing($number . "! ");
-    $number = $number + 2;
-    $this->sing($number . "! ");
-    $this->sing("Who do we appreciate?");
-    $number = 17;
-    $this->sing($number . "! ");
-    $number = $this->getNextPrime($number);
-    $this->sing($number . "! ");
-    $number = $this->getNextPrime($number);
-    $this->sing($number . "! ");
-    $number = $this->getNextPrime($number);
-    $this->sing($number . "! ");
-    $this->sing("These are the primes, that we find fine!");
-  }
-private function getNextPrime($number)
-  {
-      switch ($number)
-      {
-          case 13 :
-              return 17;
-          case 17 :
-              return 19;
-          case 19 :
-              return 23;
-          case 23 :
-              return 29;
-      }
-      return 0;
-  }
+    public function singCheers(): void
+    {
+        $number = 2;
+        $this->sing($number . "! ");
+        $number = $number + 2;
+        $this->sing($number . "! ");
+        $number = $number + 2;
+        $this->sing($number . "! ");
+        $number = $number + 2;
+        $this->sing($number . "! ");
+        $this->sing("Who do we appreciate?");
+        $number = 17;
+        $this->sing($number . "! ");
+        $number = $this->getNextPrime($number);
+        $this->sing($number . "! ");
+        $number = $this->getNextPrime($number);
+        $this->sing($number . "! ");
+        $number = $this->getNextPrime($number);
+        $this->sing($number . "! ");
+        $this->sing("These are the primes, that we find fine!");
+    }
+
+    private function getNextPrime(int $number): int
+    {
+        switch ($number) {
+            case 13 :
+                return 17;
+            case 17 :
+                return 19;
+            case 19 :
+                return 23;
+            case 23 :
+                return 29;
+        }
+        return 0;
+    }
 }

--- a/src/Lesson3B.php
+++ b/src/Lesson3B.php
@@ -11,7 +11,7 @@ class Lesson3B extends Song
         switch ($style) {
             case 1 :
                 foreach ($names as $name) {
-                    if (substr( $name, 0, strlen("L")) === "L") {
+                    if (substr($name, 0, strlen("L")) === "L") {
                         $this->sing("Hip Hip Horray! For " . $name);
                     } else {
                         $this->sing("Hello " . $name . ", it's nice to meet you.");
@@ -20,7 +20,7 @@ class Lesson3B extends Song
                 break;
             case 2 :
                 foreach ($names as $name) {
-                    if (strpos( $name, "a",0) != false) {
+                    if (strpos($name, "a", 0) != false) {
                         $this->sing(strtoupper($name) . "! Yay " . $name . "!");
                     } else {
                         $this->sing("Hello " . $name . ", it's nice to meet you.");

--- a/src/Lesson3B.php
+++ b/src/Lesson3B.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace LearnWithLlew;
 

--- a/src/Song.php
+++ b/src/Song.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace LearnWithLlew;
 

--- a/tests/RegressionTest.php
+++ b/tests/RegressionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace LearningWithLlew\Tests;
 
 use ApprovalTests\Approvals;

--- a/tests/RegressionTest.php
+++ b/tests/RegressionTest.php
@@ -36,6 +36,7 @@ class RegressionTest extends TestCase
         // Assert
         Approvals::verifyString($lesson->song);
     }
+
     /** @test */
     public function shouldTestLesson2B()
     {
@@ -58,6 +59,7 @@ class RegressionTest extends TestCase
         // Assert
         Approvals::verifyString($lesson->song);
     }
+
     /** @test */
     public function shouldTestLesson3B()
     {


### PR DESCRIPTION
A couple type hints were missing.  In addition since everything in here has type hinting we can turn on strict_types to enforce strict typing.